### PR TITLE
Added framework for switching on v.type.

### DIFF
--- a/lib/abrp.js
+++ b/lib/abrp.js
@@ -113,6 +113,7 @@ function collectHighFrequencyMetrics() {
 function getOvmsMetrics() {
   // https://docs.openvehicles.com/en/latest/userguide/metrics.html
   const metricNames = [
+    'v.type',
     'v.b.current',
     'v.b.power',
     'v.b.range.ideal',
@@ -120,6 +121,7 @@ function getOvmsMetrics() {
     'v.b.soh',
     'v.b.temp',
     'v.b.voltage',
+    'v.c.charging',
     'v.c.kwh',
     'v.c.mode',
     'v.c.state', // v.c.charging is also true when regenerating, which isn't what is wanted
@@ -176,7 +178,7 @@ function mapMetricsToTelemetry(metrics) {
   // Array.prototype.includes() not supported in duktape
   // TODO: confirm if is_charging is supposed to be true if regenerative braking is
   // charging the battery.
-  const is_charging = chargingStates.indexOf(metrics['v.c.state']) > -1
+  var is_charging = chargingStates.indexOf(metrics['v.c.state']) > -1;
   // The instrument range reported by the Nissan Leaf OVMS metrics doesn't
   // appear to update when the car is parked and then charged. So, use the
   // generic vehicle ideal range when it's more than 10% of the reported
@@ -184,6 +186,21 @@ function mapMetricsToTelemetry(metrics) {
   const instrumentRange = round(metrics['xnl.v.b.range.instrument']) || 0
   const idealRange = round(metrics['v.b.range.ideal'])
   // https://documenter.getpostman.com/view/7396339/SWTK5a8w
+
+  // Add switches based on v.type
+  const vehicleType = metrics['v.type'];
+  switch (vehicleType) {
+    case 'SUBSOL':
+    case 'TOYBZ4X':
+      is_charging = metrics['v.c.charging'];
+      break;
+
+      // Add more cases for other vehicle types if needed
+    default:
+
+      break;
+  }
+  
   const telemetry = {
     utc: round(Date.now() / 1000),
     soc: round(metrics['xnl.v.b.soc.instrument']) || round(metrics['v.b.soc']),


### PR DESCRIPTION
Added framework for different metric mapping based on v.type.

Added support for Toyota e-TNGA vehicles (Toyota bZ4X and Subaru Solterra) as an example, but more significant refactoring would be required to align it with the OVMS standard metrics.

resolves #14 
