### PR TITLE
Refactor metrics to telemetry to support vehicle differences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 2.1.0, 2023-XX-XX, `kezarjg`
+
+- Programattically determine what vehicle metrics are supported and only add supported metrics to the telemetry object.
+- Additional telemetry field sent to ABRP
+  - `capacity`
+
 ## Version 2.0.1, 2023-01-02, `dteirney` and `Edwintenhaaf`
 
 - Change to HTTPS for the ABRP API endpoint

--- a/lib/abrp.js
+++ b/lib/abrp.js
@@ -7,10 +7,20 @@ const MIN_CALIBRATION_SPEED = 70 // kph
 const OVMS_API_KEY = '32b2162f-9599-4647-8139-66e9f9528370'
 const VERSION = '2.1.0-alpha'
 
+/**
+Creates a shallow copy of the provided object.
+@param {Object} obj - The object to be cloned.
+@returns {Object} - A new object that is a shallow copy of the input object.
+*/
 function clone(obj) {
   return Object.assign({}, obj)
 }
 
+/**
+Checks if the provided value is null or undefined.
+@param {*} value - The value to be checked.
+@returns {boolean} - Returns true if the value is null or undefined, otherwise returns false.
+*/
 function isNil(value) {
   return value == null
 }
@@ -19,7 +29,11 @@ function timestamp() {
   return new Date().toLocaleString()
 }
 
-// simple console shim
+/**
+ * Creates a logger object with various logging functions.
+ * 
+ * @returns {Object} - An object with logging functions (log, debug, error, info, warn).
+ */
 function logger() {
   function log(message, obj) {
     print(message + (obj ? ' ' + JSON.stringify(obj) : '') + '\n')
@@ -52,6 +66,11 @@ function logger() {
   }
 }
 
+/**
+Creates a new object by omitting properties with null or undefined values from the provided object.
+@param {Object} obj - The object from which properties with null or undefined values will be omitted.
+@returns {Object} - A new object that is a clone of the input object with null or undefined properties omitted.
+*/
 function omitNil(obj) {
   const cloned = clone(obj)
   const keys = Object.keys(cloned)
@@ -63,6 +82,12 @@ function omitNil(obj) {
   return cloned
 }
 
+/**
+Rounds the given number to the specified precision.
+@param {number} number - The number to be rounded.
+@param {number} [precision] - The desired precision (number of decimal places) for the rounded result. Defaults to 0 if not provided.
+@returns {number} - The rounded number, or the original number if it is 0, null, or undefined.
+*/
 function round(number, precision) {
   if (!number) {
     return number // could be 0, null or undefined
@@ -70,6 +95,11 @@ function round(number, precision) {
   return Number(number.toFixed(precision || 0))
 }
 
+/**
+Calculates the median power metric from the given array of readings.
+@param {Array} array - An array of readings containing power metrics.
+@returns {Object|null} - The median power metric reading, or null if the input array is empty.
+*/
 function medianPowerMetrics(array) {
   if (!array.length) {
     return null
@@ -97,6 +127,9 @@ var lastSentTelemetry = {
 var subscribedLowFrequency = false
 var subscribedHighFrequency = false
 
+/**
+Collects high-frequency metrics for power and speed and stores them in the collectedMetrics array.
+*/
 function collectHighFrequencyMetrics() {
   const highFrequencyMetricNames = ['v.b.power', 'v.p.speed']
   const metrics = OvmsMetrics.GetValues(highFrequencyMetricNames)
@@ -110,10 +143,21 @@ function collectHighFrequencyMetrics() {
   }
 }
 
+/**
+ * Retrieves the ABRP configuration values for the user.
+ * 
+ * @returns {object} The ABRP configuration object containing user-specific values.
+ */
 function getUsrAbrpConfig() {
   return OvmsConfig.GetValues('usr', 'abrp.')
 }
 
+/**
+Determines if a telemetry change is significant based on a comparison between current and previous telemetry data.
+@param {Object} currentTelemetry - The current telemetry data object.
+@param {Object} previousTelemetry - The previous telemetry data object.
+@returns {boolean} - Returns true if the telemetry change is considered significant, false otherwise.
+*/
 function isSignificantTelemetryChange(currentTelemetry, previousTelemetry) {
   // Significant if the SOC changes so that it updates in ABRP as soon as
   // possible after it's changed within the vehicle.
@@ -141,15 +185,25 @@ function isSignificantTelemetryChange(currentTelemetry, previousTelemetry) {
   return false
 }
 
+/**
+Checks if all the required metrics are supported by the OvmsMetrics system.
+@param {Array} requiredMetrics - An array of required metric names to be checked.
+@returns {boolean} - Returns true if all the required metrics are supported, false otherwise.
+*/
 function isOvmsMetricSupported(requiredMetrics) {
   for (var i = 0; i < requiredMetrics.length; i++) {
     if (!OvmsMetrics.HasValue(requiredMetrics[i])) {
-      return false; // Return 0 if any metric is not supported
+      return false; // Return false if any metric is not supported
     }
   }
-  return true; // Return 1 if all metrics are supported
+  return true; // All metrics are supported
 }
 
+/**
+Retrieves the value of the specified OVMS metric parameter.
+@param {string} parameter - The parameter name of the OVMS metric.
+@returns {[boolean, any]} - Returns a two-element array. The first element indicates whether the metric is supported, and the second element is the metric value. If the parameter is unrecognized, the array will contain [false, null].
+*/
 function getOVMSMetric(parameter) {
 
   const vehicleType = OvmsMetrics.GetValues('v.type');
@@ -472,6 +526,11 @@ function getOVMSMetric(parameter) {
 
 }
 
+/**
+ * Creates a telemetry object with the specified parameters.
+ * 
+ * @returns {Object} The telemetry object containing the supported parameters and their values.
+ */
 function createTelemetry() {
   const IternioParameters = [
     "utc",
@@ -518,6 +577,10 @@ function createTelemetry() {
   return telemetry;  // Returning the telemetry object
 }
 
+/**
+Sends telemetry data to the ABRP (A Better Routeplanner) API.
+@param {Object} telemetry - The telemetry data to be sent to ABRP.
+*/
 function sendTelemetry(telemetry) {
   const config = getUsrAbrpConfig()
   const token = config.user_token
@@ -546,6 +609,9 @@ function sendTelemetry(telemetry) {
   })
 }
 
+/**
+Sends telemetry data to ABRP (A Better Routeplanner) if necessary, based on specified conditions and timing considerations.
+*/
 function sendTelemetryIfNecessary() {
   const maxCalibrationTimeout = 5 // seconds
   const maxChargingTimeout = 30 * 60 // 30 minutes
@@ -603,6 +669,11 @@ function sendTelemetryIfNecessary() {
   }
 }
 
+/**
+ * Validates the ABRP configuration for the user.
+ * 
+ * @returns {boolean} True if the configuration is valid, false otherwise.
+ */
 function validateUsrAbrpConfig() {
   const config = getUsrAbrpConfig()
   if (!config.user_token) {
@@ -616,6 +687,10 @@ function validateUsrAbrpConfig() {
   return true
 }
 
+/**
+Subscribes to high-frequency metric collection by subscribing to the 'ticker.1' PubSub channel.
+If not already subscribed, the 'collectHighFrequencyMetrics' function is registered as the event handler for the subscription.
+*/
 function subscribeHighFrequency() {
   if (!subscribedHighFrequency) {
     console.debug('Subscribing to collectHighFrequencyMetrics')
@@ -624,6 +699,11 @@ function subscribeHighFrequency() {
   subscribedHighFrequency = true
 }
 
+/**
+ * Subscribes to low-frequency events for sending telemetry if necessary.
+ * If not already subscribed, it subscribes to specific events ('ticker.10', 'vehicle.on', 'vehicle.off')
+ * and calls the 'sendTelemetryIfNecessary' function.
+ */
 function subscribeLowFrequency() {
   if (!subscribedLowFrequency) {
     console.debug('Subscribing to sendTelemetryIfNecessary')
@@ -634,6 +714,11 @@ function subscribeLowFrequency() {
   subscribedLowFrequency = true
 }
 
+/**
+Unsubscribes from low-frequency metric collection by unsubscribing from the 'sendTelemetryIfNecessary' PubSub channel.
+If already subscribed, the 'sendTelemetryIfNecessary' function is unregistered as the event handler for the subscription.
+Additionally, it unsubscribes from high-frequency metric collection by calling the 'unsubscribeHighFrequency' function.
+*/
 function unsubscribeLowFrequency() {
   if (subscribedLowFrequency) {
     // unsubscribe can be passed the subscription identifier or the function
@@ -646,6 +731,10 @@ function unsubscribeLowFrequency() {
   unsubscribeHighFrequency()
 }
 
+/**
+Unsubscribes from high-frequency metric collection by unsubscribing from the 'collectHighFrequencyMetrics' PubSub channel.
+If already subscribed, the 'collectHighFrequencyMetrics' function is unregistered as the event handler for the subscription.
+*/
 function unsubscribeHighFrequency() {
   if (subscribedHighFrequency) {
     console.debug('Unsubscribing from collectHighFrequencyMetrics')
@@ -654,7 +743,10 @@ function unsubscribeHighFrequency() {
   subscribedHighFrequency = false
 }
 
-// API method abrp.onetime():
+/**
+ * Executes a one-time telemetry sending process.
+ * Validates the user's ABRP configuration, creates telemetry data, and sends it.
+ */
 function onetime() {
   if (!validateUsrAbrpConfig()) {
     return
@@ -663,7 +755,10 @@ function onetime() {
   sendTelemetry(telemetry)
 }
 
-// API method abrp.info():
+/**
+ * Logs information about telemetry data to the console.
+ * Retrieves telemetry data using the `createTelemetry` function and logs specific properties if they exist.
+ */
 function info() {
   const telemetry = createTelemetry();
   // space before units as per NIST guidelines https://physics.nist.gov/cuu/Units/checklist.html
@@ -727,13 +822,18 @@ function info() {
   }
 }
 
-// API method abrp.resetConfig()
+/**
+ * Resets the ABRP configuration to default values.
+ */
 function resetConfig() {
   OvmsConfig.SetValues('usr', 'abrp.', {})
   OvmsNotify.Raise('info', 'usr.abrp.status', 'ABRP::usr abrp config reset')
 }
 
-// API method abrp.send():
+/**
+ * Controls the sending of data based on the provided `onoff` flag.
+ * @param {boolean} onoff - Indicates whether to start or stop sending data.
+ */
 function send(onoff) {
   if (onoff) {
     if (!validateUsrAbrpConfig()) {

--- a/lib/abrp.js
+++ b/lib/abrp.js
@@ -5,7 +5,7 @@
 const DEBUG = false
 const MIN_CALIBRATION_SPEED = 70 // kph
 const OVMS_API_KEY = '32b2162f-9599-4647-8139-66e9f9528370'
-const VERSION = '2.0.2-working'
+const VERSION = '2.1.0-alpha'
 
 function clone(obj) {
   return Object.assign({}, obj)

--- a/lib/abrp.js
+++ b/lib/abrp.js
@@ -7,10 +7,20 @@ const MIN_CALIBRATION_SPEED = 70 // kph
 const OVMS_API_KEY = '32b2162f-9599-4647-8139-66e9f9528370'
 const VERSION = '2.1.0-alpha'
 
+/**
+Creates a shallow copy of the provided object.
+@param {Object} obj - The object to be cloned.
+@returns {Object} - A new object that is a shallow copy of the input object.
+*/
 function clone(obj) {
   return Object.assign({}, obj)
 }
 
+/**
+Checks if the provided value is null or undefined.
+@param {*} value - The value to be checked.
+@returns {boolean} - Returns true if the value is null or undefined, otherwise returns false.
+*/
 function isNil(value) {
   return value == null
 }
@@ -19,7 +29,11 @@ function timestamp() {
   return new Date().toLocaleString()
 }
 
-// simple console shim
+/**
+ * Creates a logger object with various logging functions.
+ * 
+ * @returns {Object} - An object with logging functions (log, debug, error, info, warn).
+ */
 function logger() {
   function log(message, obj) {
     print(message + (obj ? ' ' + JSON.stringify(obj) : '') + '\n')
@@ -52,6 +66,11 @@ function logger() {
   }
 }
 
+/**
+Creates a new object by omitting properties with null or undefined values from the provided object.
+@param {Object} obj - The object from which properties with null or undefined values will be omitted.
+@returns {Object} - A new object that is a clone of the input object with null or undefined properties omitted.
+*/
 function omitNil(obj) {
   const cloned = clone(obj)
   const keys = Object.keys(cloned)
@@ -63,6 +82,12 @@ function omitNil(obj) {
   return cloned
 }
 
+/**
+Rounds the given number to the specified precision.
+@param {number} number - The number to be rounded.
+@param {number} [precision] - The desired precision (number of decimal places) for the rounded result. Defaults to 0 if not provided.
+@returns {number} - The rounded number, or the original number if it is 0, null, or undefined.
+*/
 function round(number, precision) {
   if (!number) {
     return number // could be 0, null or undefined
@@ -70,6 +95,11 @@ function round(number, precision) {
   return Number(number.toFixed(precision || 0))
 }
 
+/**
+Calculates the median power metric from the given array of readings.
+@param {Array} array - An array of readings containing power metrics.
+@returns {Object|null} - The median power metric reading, or null if the input array is empty.
+*/
 function medianPowerMetrics(array) {
   if (!array.length) {
     return null
@@ -97,6 +127,9 @@ var lastSentTelemetry = {
 var subscribedLowFrequency = false
 var subscribedHighFrequency = false
 
+/**
+Collects high-frequency metrics for power and speed and stores them in the collectedMetrics array.
+*/
 function collectHighFrequencyMetrics() {
   const highFrequencyMetricNames = ['v.b.power', 'v.p.speed']
   const metrics = OvmsMetrics.GetValues(highFrequencyMetricNames)
@@ -119,6 +152,12 @@ function getUsrAbrpConfig() {
   return OvmsConfig.GetValues('usr', 'abrp.')
 }
 
+/**
+Determines if a telemetry change is significant based on a comparison between current and previous telemetry data.
+@param {Object} currentTelemetry - The current telemetry data object.
+@param {Object} previousTelemetry - The previous telemetry data object.
+@returns {boolean} - Returns true if the telemetry change is considered significant, false otherwise.
+*/
 function isSignificantTelemetryChange(currentTelemetry, previousTelemetry) {
   // Significant if the SOC changes so that it updates in ABRP as soon as
   // possible after it's changed within the vehicle.
@@ -146,15 +185,25 @@ function isSignificantTelemetryChange(currentTelemetry, previousTelemetry) {
   return false
 }
 
+/**
+Checks if all the required metrics are supported by the OvmsMetrics system.
+@param {Array} requiredMetrics - An array of required metric names to be checked.
+@returns {boolean} - Returns true if all the required metrics are supported, false otherwise.
+*/
 function isOvmsMetricSupported(requiredMetrics) {
   for (var i = 0; i < requiredMetrics.length; i++) {
     if (!OvmsMetrics.HasValue(requiredMetrics[i])) {
-      return false; // Return 0 if any metric is not supported
+      return false; // Return false if any metric is not supported
     }
   }
-  return true; // Return 1 if all metrics are supported
+  return true; // All metrics are supported
 }
 
+/**
+Retrieves the value of the specified OVMS metric parameter.
+@param {string} parameter - The parameter name of the OVMS metric.
+@returns {[boolean, any]} - Returns a two-element array. The first element indicates whether the metric is supported, and the second element is the metric value. If the parameter is unrecognized, the array will contain [false, null].
+*/
 function getOVMSMetric(parameter) {
 
   const vehicleType = OvmsMetrics.GetValues('v.type');
@@ -528,6 +577,10 @@ function createTelemetry() {
   return telemetry;  // Returning the telemetry object
 }
 
+/**
+Sends telemetry data to the ABRP (A Better Routeplanner) API.
+@param {Object} telemetry - The telemetry data to be sent to ABRP.
+*/
 function sendTelemetry(telemetry) {
   const config = getUsrAbrpConfig()
   const token = config.user_token
@@ -556,6 +609,9 @@ function sendTelemetry(telemetry) {
   })
 }
 
+/**
+Sends telemetry data to ABRP (A Better Routeplanner) if necessary, based on specified conditions and timing considerations.
+*/
 function sendTelemetryIfNecessary() {
   const maxCalibrationTimeout = 5 // seconds
   const maxChargingTimeout = 30 * 60 // 30 minutes
@@ -631,6 +687,10 @@ function validateUsrAbrpConfig() {
   return true
 }
 
+/**
+Subscribes to high-frequency metric collection by subscribing to the 'ticker.1' PubSub channel.
+If not already subscribed, the 'collectHighFrequencyMetrics' function is registered as the event handler for the subscription.
+*/
 function subscribeHighFrequency() {
   if (!subscribedHighFrequency) {
     console.debug('Subscribing to collectHighFrequencyMetrics')
@@ -654,6 +714,11 @@ function subscribeLowFrequency() {
   subscribedLowFrequency = true
 }
 
+/**
+Unsubscribes from low-frequency metric collection by unsubscribing from the 'sendTelemetryIfNecessary' PubSub channel.
+If already subscribed, the 'sendTelemetryIfNecessary' function is unregistered as the event handler for the subscription.
+Additionally, it unsubscribes from high-frequency metric collection by calling the 'unsubscribeHighFrequency' function.
+*/
 function unsubscribeLowFrequency() {
   if (subscribedLowFrequency) {
     // unsubscribe can be passed the subscription identifier or the function
@@ -666,6 +731,10 @@ function unsubscribeLowFrequency() {
   unsubscribeHighFrequency()
 }
 
+/**
+Unsubscribes from high-frequency metric collection by unsubscribing from the 'collectHighFrequencyMetrics' PubSub channel.
+If already subscribed, the 'collectHighFrequencyMetrics' function is unregistered as the event handler for the subscription.
+*/
 function unsubscribeHighFrequency() {
   if (subscribedHighFrequency) {
     console.debug('Unsubscribing from collectHighFrequencyMetrics')

--- a/lib/abrp.js
+++ b/lib/abrp.js
@@ -113,6 +113,7 @@ function collectHighFrequencyMetrics() {
 function getOvmsMetrics() {
   // https://docs.openvehicles.com/en/latest/userguide/metrics.html
   const metricNames = [
+    'v.type',
     'v.b.current',
     'v.b.power',
     'v.b.range.ideal',
@@ -120,6 +121,7 @@ function getOvmsMetrics() {
     'v.b.soh',
     'v.b.temp',
     'v.b.voltage',
+    'v.c.charging',
     'v.c.kwh',
     'v.c.mode',
     'v.c.state', // v.c.charging is also true when regenerating, which isn't what is wanted
@@ -176,7 +178,7 @@ function mapMetricsToTelemetry(metrics) {
   // Array.prototype.includes() not supported in duktape
   // TODO: confirm if is_charging is supposed to be true if regenerative braking is
   // charging the battery.
-  const is_charging = chargingStates.indexOf(metrics['v.c.state']) > -1
+  var is_charging = chargingStates.indexOf(metrics['v.c.state']) > -1;
   // The instrument range reported by the Nissan Leaf OVMS metrics doesn't
   // appear to update when the car is parked and then charged. So, use the
   // generic vehicle ideal range when it's more than 10% of the reported
@@ -184,6 +186,21 @@ function mapMetricsToTelemetry(metrics) {
   const instrumentRange = round(metrics['xnl.v.b.range.instrument']) || 0
   const idealRange = round(metrics['v.b.range.ideal'])
   // https://documenter.getpostman.com/view/7396339/SWTK5a8w
+
+  // Add switches based on v.type
+  const vehicleType = metrics['v.type'];
+  switch (vehicleType) {
+    case 'SUBSOL':
+    case 'TOYBZ4X':
+      is_charging = metrics['v.c.charging'];
+      break;
+
+      // Add more cases for other vehicle types if needed
+    default:
+
+      break;
+  }
+  
   const telemetry = {
     utc: round(Date.now() / 1000),
     soc: round(metrics['xnl.v.b.soc.instrument']) || round(metrics['v.b.soc']),

--- a/lib/abrp.js
+++ b/lib/abrp.js
@@ -5,7 +5,7 @@
 const DEBUG = false
 const MIN_CALIBRATION_SPEED = 70 // kph
 const OVMS_API_KEY = '32b2162f-9599-4647-8139-66e9f9528370'
-const VERSION = '2.0.1'
+const VERSION = '2.0.2-working'
 
 function clone(obj) {
   return Object.assign({}, obj)
@@ -110,37 +110,6 @@ function collectHighFrequencyMetrics() {
   }
 }
 
-function getOvmsMetrics() {
-  // https://docs.openvehicles.com/en/latest/userguide/metrics.html
-  const metricNames = [
-    'v.type',
-    'v.b.current',
-    'v.b.power',
-    'v.b.range.ideal',
-    'v.b.soc',
-    'v.b.soh',
-    'v.b.temp',
-    'v.b.voltage',
-    'v.c.charging',
-    'v.c.kwh',
-    'v.c.mode',
-    'v.c.state', // v.c.charging is also true when regenerating, which isn't what is wanted
-    'v.e.parktime',
-    'v.e.temp',
-    'v.p.altitude',
-    'v.p.direction',
-    'v.p.latitude',
-    'v.p.longitude',
-    'v.p.odometer',
-    'v.p.speed',
-    // Nissan Leaf specific metrics
-    'xnl.v.b.range.instrument',
-    'xnl.v.b.soc.instrument',
-    'xnl.v.b.soh.instrument',
-  ]
-  return OvmsMetrics.GetValues(metricNames)
-}
-
 function getUsrAbrpConfig() {
   return OvmsConfig.GetValues('usr', 'abrp.')
 }
@@ -172,60 +141,381 @@ function isSignificantTelemetryChange(currentTelemetry, previousTelemetry) {
   return false
 }
 
-function mapMetricsToTelemetry(metrics) {
-  const chargingStates = ['charging', 'topoff']
-  const dcfcMode = 'performance'
-  // Array.prototype.includes() not supported in duktape
-  // TODO: confirm if is_charging is supposed to be true if regenerative braking is
-  // charging the battery.
-  var is_charging = chargingStates.indexOf(metrics['v.c.state']) > -1;
-  // The instrument range reported by the Nissan Leaf OVMS metrics doesn't
-  // appear to update when the car is parked and then charged. So, use the
-  // generic vehicle ideal range when it's more than 10% of the reported
-  // instrument range.
-  const instrumentRange = round(metrics['xnl.v.b.range.instrument']) || 0
-  const idealRange = round(metrics['v.b.range.ideal'])
-  // https://documenter.getpostman.com/view/7396339/SWTK5a8w
+function isOvmsMetricSupported(requiredMetrics) {
+  for (var i = 0; i < requiredMetrics.length; i++) {
+    if (!OvmsMetrics.HasValue(requiredMetrics[i])) {
+      return false; // Return 0 if any metric is not supported
+    }
+  }
+  return true; // Return 1 if all metrics are supported
+}
 
-  // Add switches based on v.type
-  const vehicleType = metrics['v.type'];
-  switch (vehicleType) {
-    case 'SUBSOL':
-    case 'TOYBZ4X':
-      is_charging = metrics['v.c.charging'];
+function getOVMSMetric(parameter) {
+
+  const vehicleType = OvmsMetrics.GetValues('v.type');
+
+  // Set return values to default
+  var isSupported = false;
+  var value = null;
+
+  // Initialize working variables 
+  var requiredMetrics, metrics;
+
+  // Implement case structure to handle each parameter
+  switch (parameter) {
+
+    case "utc":
+      // utc [s]: Current UTC timestamp (epoch) in seconds (note, not milliseconds!)
+      isSupported = true;
+      value = Date.now() / 1000;
       break;
 
-      // Add more cases for other vehicle types if needed
+    case "soc":
+      // soc [SoC %]: State of Charge of the vehicle (what's displayed on the dashboard of the vehicle is preferred)
+      // 'v.b.soc' - State of charge [%]
+
+      switch (vehicleType) {
+        case 'NL':
+          requiredMetrics = ['xnl.v.b.soc.instrument'];
+          isSupported = isOvmsMetricSupported(requiredMetrics);
+
+          if (isSupported) {
+            metrics = OvmsMetrics.GetValues(requiredMetrics);
+            value = metrics['xnl.v.b.soc.instrument'];
+          }
+          break;
+
+        default:
+          requiredMetrics = ['v.b.soc'];
+          isSupported = isOvmsMetricSupported(requiredMetrics);
+
+          if (isSupported) {
+            metrics = OvmsMetrics.GetValues(requiredMetrics);
+            value = metrics['v.b.soc'];
+          }
+          break;
+      }
+      break;
+
+    case "power":
+      // power [kW]: Instantaneous power output/input to the vehicle. Power output is positive, power input is negative (charging)
+      // 'v.b.power' - Main battery momentary power [kW] (output=positive)
+      requiredMetrics = ['v.b.power'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.b.power'];
+      }
+      break;
+
+    case "speed":
+      // speed [km/h]: Vehicle speed
+      // 'v.p.speed' - Vehicle speed [kph]
+      requiredMetrics = ['v.p.speed'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.p.speed'];
+      }
+      break;
+
+    case "lat":
+      // lat [°]: Current vehicle latitude
+      // 'v.p.latitude'
+      requiredMetrics = ['v.p.latitude'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.p.latitude'];
+      }
+      break;
+
+    case "lon":
+      // lon [°]: Current vehicle longitude
+      // 'v.p.longitude'
+      requiredMetrics = ['v.p.longitude'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.p.longitude'];
+      }
+      break;
+
+    case "is_charging":
+      // is_charging [bool or 1/0]: Determines vehicle state. 0 is not charging, 1 is charging
+      // 'v.c.charging' - True = currently charging
+      switch (vehicleType) {
+        case 'NL':
+          // 'v.c.state' - charging, topoff, done, prepare, timerwait, heating, stopped
+          requiredMetrics = ['v.c.state'];
+          isSupported = isOvmsMetricSupported(requiredMetrics);
+          if (isSupported) {
+            var chargingStates = ['charging', 'topoff']
+            metrics = OvmsMetrics.GetValues(requiredMetrics);
+            // Array.prototype.includes() not supported in duktape
+            // TODO: confirm if is_charging is supposed to be true if regenerative braking is
+            // charging the battery.
+            value = chargingStates.indexOf(metrics['v.c.state']) > -1;
+          }
+          break;
+        default:
+          requiredMetrics = ['v.c.charging'];
+          isSupported = isOvmsMetricSupported(requiredMetrics);
+
+          if (isSupported) {
+            metrics = OvmsMetrics.GetValues(requiredMetrics);
+            value = metrics['v.c.charging'];
+          }
+          break;
+      }
+      break;
+
+    case "is_dcfc":
+      // is_dcfc [bool or 1/0]: If is_charging, indicate if this is DC fast charging
+      // 'v.c.mode' - standard, range, performance, storage
+      requiredMetrics = ['v.c.mode'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.c.mode'] === 'performance';
+      }
+      break;
+
+    case "is_parked":
+      // is_parked [bool or 1/0]: If the vehicle gear is in P (or the driver has left the car)
+      // 'v.e.parktime'
+      requiredMetrics = ['v.e.parktime'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.e.parktime'] > 0;
+      }
+      break;
+
+    case "capacity":
+      // capacity [kWh]: Estimated usable battery capacity (can be given together with soh, but usually not)
+      // 'v.b.cac' - Calculated capacity [Ah]
+      // 'v.b.voltage.nominal' - TODO: This metric doesn't exist yet
+      requiredMetrics = ['v.b.cac', 'v.b.voltage.nominal'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.b.cac'] * metrics['v.b.voltage.nominal'];
+      }
+      break;
+
+    case "kwh_charged":
+      // kwh_charged [kWh]: Measured energy input while charging. Typically a cumulative total, but also supports individual sessions.
+      // 'v.c.charging' - True = currently charging
+      // 'v.c.kwh' - Energy sum for running charge [kWh]
+      requiredMetrics = ['v.c.charging', 'v.c.kwh'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.c.charging'] ? metrics['v.c.kwh'] : 0;
+      }
+      break;
+
+    case "soh":
+      // soh [%]: State of Health of the battery. 100 = no degradation
+      // 'v.b.soh' - State of health [%]
+
+      switch (vehicleType) {
+        case 'NL':
+          requiredMetrics = ['xnl.v.b.soh.instrument'];
+          isSupported = isOvmsMetricSupported(requiredMetrics);
+          if (isSupported) {
+            metrics = OvmsMetrics.GetValues(requiredMetrics);
+            value = metrics['xnl.v.b.soh.instrument'];
+          }
+          break;
+
+        default:
+          requiredMetrics = ['v.b.soh'];
+          isSupported = isOvmsMetricSupported(requiredMetrics);
+
+          if (isSupported) {
+            metrics = OvmsMetrics.GetValues(requiredMetrics);
+            value = metrics['v.b.soh'];
+          }
+          break;
+      }
+      break;
+
+    case "heading":
+      // heading [°]: Current heading of the vehicle. This will take priority over phone heading, so don't include if not accurate.
+      // 'v.p.direction'
+      requiredMetrics = ['v.p.direction'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.p.direction'];
+      }
+      break;
+
+    case "elevation":
+      // elevation [m]: Vehicle's current elevation. If not given, will be looked up from location (but may miss 3D structures)
+      // 'v.p.altitude'
+      requiredMetrics = ['v.p.altitude'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.p.altitude'];
+      }
+      break;
+
+    case "ext_temp":
+      // ext_temp [°C]: Outside temperature measured by the vehicle
+      // 'v.e.temp' - Ambient temperature [°C]
+      requiredMetrics = ['v.e.temp'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.e.temp'];
+      }
+      break;
+
+    case "batt_temp":
+      // batt_temp [°C]: Battery temperature
+      // 'v.b.temp' - Battery temperature [°C]
+      requiredMetrics = ['v.b.temp'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.b.temp'];
+      }
+      break;
+
+    case "voltage":
+      // voltage [V]: Battery pack voltage
+      // 'v.b.voltage' - Main battery momentary voltage [V]
+      requiredMetrics = ['v.b.voltage'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.b.voltage'];
+      }
+      break;
+
+    case "current":
+      // current [A]: Battery pack current (similar to power: output is positive, input (charging) is negative.)
+      // 'v.b.current' - Main battery momentary current [A] (output=positive)
+      requiredMetrics = ['v.b.current'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.b.current'];
+      }
+      break;
+
+    case "odometer":
+      // odometer [km]: Current odometer reading in km.
+      // 'v.p.odometer'
+      requiredMetrics = ['v.p.odometer'];
+      isSupported = isOvmsMetricSupported(requiredMetrics);
+
+      if (isSupported) {
+        metrics = OvmsMetrics.GetValues(requiredMetrics);
+        value = metrics['v.p.odometer'];
+      }
+      break;
+
+    case "est_battery_range":
+      // est_battery_range [km]: Estimated remaining range of the vehicle (according to the vehicle)
+      // 'v.b.range.est' - Estimated range [km]
+      switch (vehicleType) {
+        case 'NL':
+          requiredMetrics = ['xnl.v.b.range.instrument', 'v.b.range.ideal'];
+          isSupported = isOvmsMetricSupported(requiredMetrics);
+
+          if (isSupported) {
+            var instrumentRange, idealRange
+            metrics = OvmsMetrics.GetValues(requiredMetrics);
+            instrumentRange = round(metrics['xnl.v.b.range.instrument']) || 0;
+            idealRange = round(metrics['v.b.range.ideal']);
+            value = idealRange > 1.1 * instrumentRange ? idealRange : instrumentRange;
+          }
+          break;
+
+        default:
+          requiredMetrics = ['v.b.range.est'];
+          isSupported = isOvmsMetricSupported(requiredMetrics);
+
+          if (isSupported) {
+            metrics = OvmsMetrics.GetValues(requiredMetrics);
+            value = metrics['v.b.range.est'];
+          }
+          break;
+      }
+      break;
+
     default:
-
+      // If an unrecognized parameter is received, it will return isSupported = false
       break;
   }
-  
-  const telemetry = {
-    utc: round(Date.now() / 1000),
-    soc: round(metrics['xnl.v.b.soc.instrument']) || round(metrics['v.b.soc']),
-    power: round(metrics['v.b.power'], 2), // ~ nearest 10W of precision
-    speed: round(metrics['v.p.speed']),
-    lat: round(metrics['v.p.latitude'], 5), // ~1.11 m of precision
-    lon: round(metrics['v.p.longitude'], 5), // ~1.11 m of precision
-    is_charging,
-    is_dcfc: is_charging && dcfcMode === metrics['v.c.mode'],
-    is_parked: metrics['v.e.parktime'] > 0,
-    kwh_charged: is_charging ? round(metrics['v.c.kwh'], 1) : 0,
-    soh: round(metrics['xnl.v.b.soh.instrument']) || round(metrics['v.b.soh']),
-    heading: round(metrics['v.p.direction'], 1),
-    elevation: round(metrics['v.p.altitude'], 1),
-    ext_temp: round(metrics['v.e.temp']),
-    batt_temp: round(metrics['v.b.temp']),
-    voltage: round(metrics['v.b.voltage']),
-    current: round(metrics['v.b.current'], 1),
-    odometer: round(metrics['v.p.odometer']),
-    est_battery_range:
-      idealRange > 1.1 * instrumentRange ? idealRange : instrumentRange,
+
+  return [isSupported, value];
+
+}
+
+function createTelemetry() {
+  const IternioParameters = [
+    "utc",
+    "soc",
+    "power",
+    "speed",
+    "lat",
+    "lon",
+    "is_charging",
+    "is_dcfc",
+    "is_parked",
+    "capacity",
+    "kwh_charged",
+    "soh",
+    "heading",
+    "elevation",
+    "ext_temp",
+    "batt_temp",
+    "voltage",
+    "current",
+    "odometer",
+    "est_battery_range"
+  ] 
+
+  const telemetry = {};  // Creating an empty object to hold the telemetry data
+
+  // Iterating over the parameters array and adding properties to the telemetry object
+  var i, n;
+  for (i = 0, n = IternioParameters.length; i < n; i++) {
+    var result;
+    var isSupported;
+    var value;
+
+    result = getOVMSMetric(IternioParameters[i]);
+
+    isSupported = result[0];
+    value = result[1];
+
+    if (isSupported) {
+      telemetry[IternioParameters[i]] = value;  // Add the value to the telemetry object
+    }
   }
-  // console.debug('Mapped ABRP telemetry', telemetry)
-  // Omit nil properties as ABRP doesn't appreciate getting them.
-  return omitNil(telemetry)
+
+  return telemetry;  // Returning the telemetry object
 }
 
 function sendTelemetry(telemetry) {
@@ -262,8 +552,7 @@ function sendTelemetryIfNecessary() {
   const staleConnectionTimeout = 3 * 60 // 3 minutes for OVMS API Key
   const staleConnectionTimeoutBuffer = 20 // seconds
 
-  const metrics = getOvmsMetrics()
-  const currentTelemetry = mapMetricsToTelemetry(metrics)
+  const currentTelemetry = createTelemetry();
 
   // If being collected, somewhat smooth the point in time power and speed
   // reported using the metrics for the median power entry from those collected
@@ -370,35 +659,72 @@ function onetime() {
   if (!validateUsrAbrpConfig()) {
     return
   }
-  const metrics = getOvmsMetrics()
-  const telemetry = mapMetricsToTelemetry(metrics)
+  const telemetry = createTelemetry();
   sendTelemetry(telemetry)
 }
 
 // API method abrp.info():
 function info() {
-  const metrics = getOvmsMetrics()
-  const telemetry = mapMetricsToTelemetry(metrics)
+  const telemetry = createTelemetry();
   // space before units as per NIST guidelines https://physics.nist.gov/cuu/Units/checklist.html
-  console.log('Plugin Version:   ' + VERSION)
-  console.log('State of Charge:  ' + telemetry.soc + ' %')
-  console.log('Battery Power:    ' + telemetry.power + ' kW')
-  console.log('Vehicle Speed:    ' + telemetry.speed + ' kph')
-  console.log('GPS Latitude:     ' + telemetry.lat + ' °')
-  console.log('GPS Longitude:    ' + telemetry.lon + ' °')
-  console.log('Charging:         ' + telemetry.is_charging)
-  console.log('DC Fast Charging: ' + telemetry.is_dcfc)
-  console.log('Parked:           ' + telemetry.is_parked)
-  console.log('Charged kWh:      ' + telemetry.kwh_charged)
-  console.log('State of Health:  ' + telemetry.soh + ' %')
-  console.log('GPS Heading:      ' + telemetry.heading + ' °')
-  console.log('GPS Elevation:    ' + telemetry.elevation + ' m')
-  console.log('External Temp:    ' + telemetry.ext_temp + ' °C')
-  console.log('Battery Temp:     ' + telemetry.batt_temp + ' °C')
-  console.log('Battery Voltage:  ' + telemetry.voltage + ' V')
-  console.log('Battery Current:  ' + telemetry.current + ' A')
-  console.log('Odometer:         ' + telemetry.odometer + ' km')
-  console.log('Estimated Range:  ' + telemetry.est_battery_range + ' km')
+  console.log('Plugin Version:   ' + VERSION);
+  if (telemetry.hasOwnProperty("soc")) {
+    console.log('State of Charge:  ' + telemetry.soc + ' %');
+  }
+  if (telemetry.hasOwnProperty("power")) {
+    console.log('Battery Power:    ' + telemetry.power + ' kW');
+  }
+  if (telemetry.hasOwnProperty("speed")) {
+    console.log('Vehicle Speed:    ' + telemetry.speed + ' kph');
+  }
+  if (telemetry.hasOwnProperty("lat")) {
+    console.log('GPS Latitude:     ' + telemetry.lat + ' °');
+  }
+  if (telemetry.hasOwnProperty("lon")) {
+    console.log('GPS Longitude:    ' + telemetry.lon + ' °');
+  }
+  if (telemetry.hasOwnProperty("is_charging")) {
+    console.log('Charging:         ' + telemetry.is_charging);
+  }
+  if (telemetry.hasOwnProperty("is_dcfc")) {
+    console.log('DC Fast Charging: ' + telemetry.is_dcfc);
+  }
+  if (telemetry.hasOwnProperty("is_parked")) {
+    console.log('Parked:           ' + telemetry.is_parked);
+  }
+  if (telemetry.hasOwnProperty("capacity")) {
+    console.log('Capacity          ' + telemetry.capacity + ' Ah');
+  }
+  if (telemetry.hasOwnProperty("kwh_charged")) {
+    console.log('Charged kWh:      ' + telemetry.kwh_charged) + ' kWh';
+  }
+  if (telemetry.hasOwnProperty("soh")) {
+    console.log('State of Health:  ' + telemetry.soh + ' %');
+  }
+  if (telemetry.hasOwnProperty("heading")) {
+    console.log('GPS Heading:      ' + telemetry.heading + ' °');
+  }
+  if (telemetry.hasOwnProperty("elevation")) {
+    console.log('GPS Elevation:    ' + telemetry.elevation + ' m');
+  }
+  if (telemetry.hasOwnProperty("ext_temp")) {
+    console.log('External Temp:    ' + telemetry.ext_temp + ' °C');
+  }
+  if (telemetry.hasOwnProperty("batt_temp")) {
+    console.log('Battery Temp:     ' + telemetry.batt_temp + ' °C');
+  }
+  if (telemetry.hasOwnProperty("voltage")) {
+    console.log('Battery Voltage:  ' + telemetry.voltage + ' V');
+  }
+  if (telemetry.hasOwnProperty("current")) {
+    console.log('Battery Current:  ' + telemetry.current + ' A');
+  }
+  if (telemetry.hasOwnProperty("odometer")) {
+    console.log('Odometer:         ' + telemetry.odometer + ' km');
+  }
+  if (telemetry.hasOwnProperty("est_battery_range")) {
+    console.log('Estimated Range:  ' + telemetry.est_battery_range + ' km');
+  }
 }
 
 // API method abrp.resetConfig()
@@ -430,6 +756,7 @@ function send(onoff) {
     OvmsNotify.Raise('info', 'usr.abrp.status', 'ABRP::stopped')
   }
 }
+
 
 module.exports = {
   medianPowerMetrics, // jest

--- a/lib/abrp.js
+++ b/lib/abrp.js
@@ -110,6 +110,11 @@ function collectHighFrequencyMetrics() {
   }
 }
 
+/**
+ * Retrieves the ABRP configuration values for the user.
+ * 
+ * @returns {object} The ABRP configuration object containing user-specific values.
+ */
 function getUsrAbrpConfig() {
   return OvmsConfig.GetValues('usr', 'abrp.')
 }
@@ -472,6 +477,11 @@ function getOVMSMetric(parameter) {
 
 }
 
+/**
+ * Creates a telemetry object with the specified parameters.
+ * 
+ * @returns {Object} The telemetry object containing the supported parameters and their values.
+ */
 function createTelemetry() {
   const IternioParameters = [
     "utc",
@@ -603,6 +613,11 @@ function sendTelemetryIfNecessary() {
   }
 }
 
+/**
+ * Validates the ABRP configuration for the user.
+ * 
+ * @returns {boolean} True if the configuration is valid, false otherwise.
+ */
 function validateUsrAbrpConfig() {
   const config = getUsrAbrpConfig()
   if (!config.user_token) {
@@ -624,6 +639,11 @@ function subscribeHighFrequency() {
   subscribedHighFrequency = true
 }
 
+/**
+ * Subscribes to low-frequency events for sending telemetry if necessary.
+ * If not already subscribed, it subscribes to specific events ('ticker.10', 'vehicle.on', 'vehicle.off')
+ * and calls the 'sendTelemetryIfNecessary' function.
+ */
 function subscribeLowFrequency() {
   if (!subscribedLowFrequency) {
     console.debug('Subscribing to sendTelemetryIfNecessary')
@@ -654,7 +674,10 @@ function unsubscribeHighFrequency() {
   subscribedHighFrequency = false
 }
 
-// API method abrp.onetime():
+/**
+ * Executes a one-time telemetry sending process.
+ * Validates the user's ABRP configuration, creates telemetry data, and sends it.
+ */
 function onetime() {
   if (!validateUsrAbrpConfig()) {
     return
@@ -663,7 +686,10 @@ function onetime() {
   sendTelemetry(telemetry)
 }
 
-// API method abrp.info():
+/**
+ * Logs information about telemetry data to the console.
+ * Retrieves telemetry data using the `createTelemetry` function and logs specific properties if they exist.
+ */
 function info() {
   const telemetry = createTelemetry();
   // space before units as per NIST guidelines https://physics.nist.gov/cuu/Units/checklist.html
@@ -727,13 +753,18 @@ function info() {
   }
 }
 
-// API method abrp.resetConfig()
+/**
+ * Resets the ABRP configuration to default values.
+ */
 function resetConfig() {
   OvmsConfig.SetValues('usr', 'abrp.', {})
   OvmsNotify.Raise('info', 'usr.abrp.status', 'ABRP::usr abrp config reset')
 }
 
-// API method abrp.send():
+/**
+ * Controls the sending of data based on the provided `onoff` flag.
+ * @param {boolean} onoff - Indicates whether to start or stop sending data.
+ */
 function send(onoff) {
   if (onoff) {
     if (!validateUsrAbrpConfig()) {


### PR DESCRIPTION
Complete refactoring of the metrics to telemetry portion of the script.

- Drop getOvmsMetrics() - metrics are now fetched as they are needed.
- Created getOVMSMetric(parameter) - This function checks to see if the vehicle module supports the parameter, then pulls it in to the telemetry object. Resolves #16 
- Added the capacity parameter to Resolve #17. However, the nominal voltage metrics is not yet added to the OVMS framework, so it won't function until that occurs.
- Replaced mapMetricsToTelemetry() with createTelemetry() to implement the new framework. Resolves #14 
- Updated info() to only log metrics that are contained in the telemetry object.

Note: This script relies on a new function in OVMS that is currently in the dev branch.