### PR TITLE
doc: change SSL instructions for GoDaddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ based on live information.
 7. Copy the content of the `ovmsmain.js` file in this repository to that new
    file and **Save**
 
-### Install the Google Subordinate CA Certificate in OVMS
+### Install the "GoDaddy Class 2 Certification Authority Root Certificate - G2" in OVMS
 
 A recent change to the APRB API means a new CA certificate is required. This 
-requires a Google subordinate CA certificate  ([GTS CA 1P5](https://pki.goog/repo/certs/gts1p5.pem)) 
+requires a "GoDaddy Class 2 Certification Authority Root Certificate - G2"  ([gdroot-g2.crt](https://certs.godaddy.com/repository/gdroot-g2.crt)) 
 to be installed into OVMS as per the instructions at the [OVMS SSL/TLS UserGuide](https://docs.openvehicles.com/en/latest/userguide/ssltls.html)
 
-The [GTS CA 1P5](https://pki.goog/repo/certs/gts1p5.pem) can be downloaded from the [Google Trust Services site](https://pki.goog/repository/).
+The [gdroot-g2.crt](https://certs.godaddy.com/repository/gdroot-g2.crt) can be downloaded from the [GoDaddy Certs Repository](https://certs.godaddy.com/repository/).
 
 1. Login to the
    [OVMS web console](https://docs.openvehicles.com/en/latest/userguide/installation.html#initial-connection-wifi-and-browser)
 2. Navigate to the **Tools** -> **Editor** menu item
 3. Create a new `trustedca` directory in `/store/` if it does not exist
-4. Create a new `gts1p5.pem` file in the `/store/trustedca` directory
-5. Copy the contents of the `gts1p5.pem` file into that file
+4. Create a new `gdroot-g2.crt` file in the `/store/trustedca` directory
+5. Copy the contents of the `gdroot-g2.crt` file into that file
 6. Navigate to the **Tools** -> **Shell** menu item
 7. Execute the following message: `tls trust reload`
 8. Execute the following message: `tls trust list` and confirm that
-   `gts1p5.pem` shows up in the list
+   `gdroot-g2.crt` shows up in the list
 
 ### Configure Plugin
 


### PR DESCRIPTION
api.iternio.com is now using a GoDaddy wildcard certificate. This PR updates README.md to reflect this change.

https://github.com/iternio/ovms-link/issues/21