### PR TITLE
fix(smart): correct inverted v.b.power sign on SQ/SE (issue #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## Version 2.3.1, 2026-07-20, `kezarjg`
+
+- Fix: correct the inverted battery-power sign on smart 453/forfour (`SQ`) and smart
+  ED/fortwo (`SE`). Both OVMS smart modules report `v.b.power` with the wrong sign —
+  negative while driving (consuming), positive while charging — the opposite of the
+  OVMS core / Iternio convention. ABRP uses `power` for consumption calibration, so it
+  read consumption as regen and the calibrated reference consumption drifted toward zero
+  (issue #40). `overrideMetricMap` now corrects `power` for these vehicles by keeping the
+  module's power magnitude and taking its sign from `v.b.current`, which the same modules
+  report correctly. This is self-healing: `v.b.current` is correct in both the current
+  (buggy) and a future upstream-fixed firmware, so once the module's `v.b.power` sign is
+  fixed the correction becomes a no-op — no plugin change needed to retire it. Only
+  `power` is affected; `current`, `is_charging`, and `is_dcfc` are unchanged. Upstream
+  firmware bugs filed separately against `vehicle_smarteq` and `vehicle_smarted`.
+
 ## Version 2.3.0, 2026-06-25, `kezarjg`
 
 - Switched telemetry to batched bulk uploads (`/1/tlm/bulk`) behind a queue, with

--- a/lib/abrp.js
+++ b/lib/abrp.js
@@ -5,7 +5,7 @@
 
 // Module constants
 const OVMS_API_KEY = '32b2162f-9599-4647-8139-66e9f9528370'
-const VERSION = '2.3.0'
+const VERSION = '2.3.1'
 const Logger = logger()
 
 // Configuration constants
@@ -308,6 +308,25 @@ function overrideMetricMap() {
           entry.requiredMetrics = ['xte.v.e.hvac.power'];
           entry.metric = function(metrics) {
             return metrics['xte.v.e.hvac.power'];
+          };
+        }
+        break;
+      case 'SQ':
+      case 'SE':
+        // smart 453/forfour (SQ) and smart ED/fortwo (SE) report v.b.power with an
+        // inverted sign (negative while driving/consuming) until the upstream firmware
+        // fix lands (see iternio/ovms-link#40). v.b.current is correctly signed
+        // (discharge-positive) in BOTH the buggy and the fixed firmware, so keep power's
+        // magnitude and take its sign from current: corrects the bug now, and becomes a
+        // no-op once v.b.power's sign is fixed upstream (no plugin change needed).
+        if (entry.key === 'power') {
+          entry.requiredMetrics = ['v.b.power', 'v.b.current'];
+          entry.metric = function(metrics) {
+            var power = metrics['v.b.power'];
+            var current = metrics['v.b.current'];
+            if (current < 0) { return -Math.abs(power); }
+            if (current > 0) { return Math.abs(power); }
+            return power; // current == 0: power is ~0, sign irrelevant
           };
         }
         break;

--- a/lib/abrp.test.js
+++ b/lib/abrp.test.js
@@ -816,3 +816,65 @@ describe('charge/drive overlap state machine', () => {
     expect(count('ticker.1')).toBe(1) // sampler subscribed at startup
   })
 })
+
+// smart 453/forfour (SQ) and smart ED/fortwo (SE) report v.b.power with an inverted
+// sign (charge-positive) until the upstream firmware fix; v.b.current is correctly
+// signed in both firmware states. overrideMetricMap corrects power by keeping its
+// magnitude and taking its sign from current: fixes the bug now, no-op once fixed
+// upstream. See iternio/ovms-link#40.
+describe('overrideMetricMap: smart SQ/SE power sign correction', () => {
+  function withSmart(present, vtype) {
+    const abrp = loadAbrp({
+      OvmsMetrics: {
+        HasValue: (k) => Object.prototype.hasOwnProperty.call(present, k),
+        GetValues: (keys) => {
+          const o = {}
+          keys.forEach((k) => {
+            o[k] = present[k]
+          })
+          return o
+        },
+        Value: (k) => (k === 'v.type' ? vtype : present[k]),
+      },
+    })
+    abrp.__test.overrideMetricMap()
+    return abrp
+  }
+
+  test('SQ: inverted power while driving is corrected to discharge-positive', () => {
+    // driving: current +9A (correct, discharge), power reported -3.0kW (inverted)
+    const abrp = withSmart({ 'v.b.power': -3.0, 'v.b.current': 9 }, 'SQ')
+    expect(abrp.getOVMSMetric('power')).toEqual([true, 3.0])
+  })
+
+  test('SQ: inverted power while charging is corrected to charge-negative', () => {
+    // charging: current -20A (correct, charge), power reported +7.0kW (inverted)
+    const abrp = withSmart({ 'v.b.power': 7.0, 'v.b.current': -20 }, 'SQ')
+    expect(abrp.getOVMSMetric('power')).toEqual([true, -7.0])
+  })
+
+  test('SQ: already-correct power (post upstream fix) passes through unchanged', () => {
+    const abrp = withSmart({ 'v.b.power': 3.0, 'v.b.current': 9 }, 'SQ')
+    expect(abrp.getOVMSMetric('power')).toEqual([true, 3.0])
+  })
+
+  test('SQ: zero current leaves power as-is (magnitude ~0, sign irrelevant)', () => {
+    const abrp = withSmart({ 'v.b.power': -0.02, 'v.b.current': 0 }, 'SQ')
+    expect(abrp.getOVMSMetric('power')).toEqual([true, -0.02])
+  })
+
+  test('SE shares the smart override: inverted power corrected', () => {
+    const abrp = withSmart({ 'v.b.power': -3.0, 'v.b.current': 9 }, 'SE')
+    expect(abrp.getOVMSMetric('power')).toEqual([true, 3.0])
+  })
+
+  test('SQ: power is unsupported when v.b.current is absent', () => {
+    const abrp = withSmart({ 'v.b.power': -3.0 }, 'SQ')
+    expect(abrp.getOVMSMetric('power')).toEqual([false, null])
+  })
+
+  test('non-smart vehicle: power is a plain passthrough (no sign correction)', () => {
+    const abrp = withSmart({ 'v.b.power': -3.0, 'v.b.current': 9 }, 'UNKNOWN')
+    expect(abrp.getOVMSMetric('power')).toEqual([true, -3.0])
+  })
+})


### PR DESCRIPTION
## What & why

Fixes the inverted battery-power sign on smart 453/forfour (`SQ`) and smart ED/fortwo (`SE`), which causes ABRP's calibrated reference consumption to drift toward zero (#40).

Both OVMS smart modules report `v.b.power` with the wrong sign - negative while driving (consuming), positive while charging - the opposite of the OVMS core / Iternio convention (positive = output/discharging). ABRP uses `power` for consumption calibration, so it reads consumption as regen and the reference consumption decays.

This was confirmed with on-device captures from both cars (telemetry as received by ABRP):

| | forfour (SQ), n=1747 | fortwo (SE), n=431 |
|---|---|---|
| `median( power / (V*I) )` | -0.999 | -1.000 |
| driving (>= 5 m/s): `current > 0` | 90% | 86% |
| driving (>= 5 m/s): `power > 0` | 7% | 10% |

Driving is net discharge (must be positive by convention), so `v.b.current` is the correctly-signed metric and `v.b.power` is inverted on both cars.

## The fix

`overrideMetricMap` now corrects `power` for `SQ`/`SE` by keeping the module's power **magnitude** and taking its **sign from `v.b.current`**:

```js
if (current < 0) { return -Math.abs(power); }
if (current > 0) { return Math.abs(power); }
return power; // current == 0: power ~0, sign irrelevant
```

**Self-healing:** `v.b.current` is correctly signed in both the current (buggy) firmware and a future upstream-fixed firmware (the fix only touches `v.b.power`). So once the module's `v.b.power` sign is corrected upstream, this override returns `v.b.power` unchanged - it becomes a no-op with no plugin change needed to retire it.

Scope is limited to `power`; `current`, `is_charging`, and `is_dcfc` are unchanged.

## Upstream

The root defect is in the OVMS vehicle-module firmware; separate firmware bugs are being filed against `vehicle_smarteq` and `vehicle_smarted`. This PR is the plugin-side workaround so affected users get correct calibration now.

## Tests

Added `overrideMetricMap` coverage for the smart override (driving correction, charging correction, post-fix no-op, zero-current, `SE` shares the override, unsupported when current absent, and non-smart passthrough). Full suite: 71 passing. `VERSION` -> `2.3.1`, CHANGELOG updated.